### PR TITLE
Fix Routing issue where # was being appended to end of the route

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,12 @@ import Newsletter from "./components/newslettter/newsletter";
 import Titleintroduction from "./components/titleintroduction/titleintroduction";
 import About from "./components/about/About";
 import Contact from "./components/contact/contact";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import {
+  BrowserRouter as Router,
+  Route,
+  Switch,
+  Redirect,
+} from "react-router-dom";
 
 //app home
 const Home = () => {
@@ -38,6 +43,13 @@ class App extends Component {
             <Route exact true path="/" component={Home} />
             <Route path="/contact" exact component={Contact} />
             <Route path="/about" exact component={About} />
+
+            {/* Create a 404 Page If route not found,
+            currently being Redirected to Home Page */}
+            <Route
+              path="/"
+              render={() => <Redirect to={{ pathname: "/" }} />}
+            />
           </Switch>
           <Newsletter />
           <Footer />

--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ import Newsletter from "./components/newslettter/newsletter";
 import Titleintroduction from "./components/titleintroduction/titleintroduction";
 import About from "./components/about/About";
 import Contact from "./components/contact/contact";
-import { HashRouter as Router, Route, Switch } from "react-router-dom";
+import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 
 //app home
 const Home = () => {


### PR DESCRIPTION
This PR fixes this issue: https://github.com/Satriaana/Satriaana-Web-Site/issues/102

The issue was caused by this PR: https://github.com/Satriaana/Satriaana-Web-Site/pull/96

This issue has been fixed by using:
BrowserRouter instead of HashRouter, due to HashRouter appends # on some routes.

You can view the current new changes in:
https://bhattaraib58.github.io/Satriaana-Web-Site/


And don't worry about /Satriaana-Web-Site/ being redirected to /, because that was a functionality that should have been before
as it's just a GitHub page, where the  /project-repo-name happened in route, which causes issues in later on production.
(This has also been addressed). 


